### PR TITLE
fix PrintColInfo for go1.10

### DIFF
--- a/src/lib/printer.go
+++ b/src/lib/printer.go
@@ -544,11 +544,11 @@ func (t *Table) PrintColInfo() {
 		return
 	}
 
-	fmt.Println("\nString Columns\n")
+	fmt.Printf("\nString Columns\n\n")
 	t.printColsOfType(STR_VAL)
-	fmt.Println("\nInteger Columns\n")
+	fmt.Printf("\nInteger Columns\n\n")
 	t.printColsOfType(INT_VAL)
-	fmt.Println("\nSet Columns\n")
+	fmt.Printf("\nSet Columns\n\n")
 	t.printColsOfType(SET_VAL)
 	fmt.Println("")
 	fmt.Println("Stats")


### PR DESCRIPTION
go 1.10 treats go vet failures as test failures. This fixes the vet issues.