### PR TITLE
[release] add basic goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,9 @@
+sign:
+  artifacts: all
+builds:
+  - binary: sybil
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64


### PR DESCRIPTION
This adds a basic config for goreleaser to assist with building and signing binaries for tagged releases.

example invocation:
```sh
$ goreleaser release --rm-dist --skip-publish
```
That will drop signed binaries and a checksum file in ./dist

Example artifacts: https://github.com/tmc/sybil/releases/tag/v0.5.0

Refs #53 