### PR TITLE
[errors] return errors instead of exiting process

### DIFF
--- a/src/cmd/cmd_aggregate.go
+++ b/src/cmd/cmd_aggregate.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
+	"os"
 
 	"github.com/logv/sybil/src/sybil"
 )
@@ -17,7 +19,9 @@ func RunAggregateCmdLine() {
 	sybil.FLAGS.DEBUG = true
 	sybil.Debug("AGGREGATING")
 
-	sybil.DecodeFlags()
+	if err := sybil.DecodeFlags(); err != nil {
+		fmt.Fprintln(os.Stderr, "aggregate: failed to decode flags:", err)
+	}
 	sybil.FLAGS.PRINT = true
 	sybil.FLAGS.ENCODE_RESULTS = false
 	sybil.Debug("AGGREGATING DIRS", dirs)

--- a/src/cmd/cmd_digest.go
+++ b/src/cmd/cmd_digest.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"os"
 
 	"github.com/logv/sybil/src/sybil"
 )
@@ -20,8 +23,10 @@ func RunDigestCmdLine() {
 	}
 	t := sybil.GetTable(sybil.FLAGS.TABLE)
 	if !t.LoadTableInfo() {
-		sybil.Warn("Couldn't read table info, exiting early")
-		return
+		// TODO use LoadTableInfo
+		err := errors.New("digest: Couldn't read table info, exiting early")
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 	t.DigestRecords()
 }

--- a/src/cmd/cmd_digest.go
+++ b/src/cmd/cmd_digest.go
@@ -30,7 +30,7 @@ func runDigestCmdLine(flags *sybil.FlagDefs) error {
 	}
 	t := sybil.GetTable(flags.TABLE)
 	if err := t.LoadTableInfo(); err != nil {
-		return nil
+		return err
 	}
 	return t.DigestRecords()
 }

--- a/src/cmd/cmd_index.go
+++ b/src/cmd/cmd_index.go
@@ -30,8 +30,12 @@ func runIndexCmdLine(flags *sybil.FlagDefs, ints []string) error {
 
 	t := sybil.GetTable(sybil.FLAGS.TABLE)
 
-	t.LoadRecords(nil)
-	t.SaveTableInfo("info")
+	if _, err := t.LoadRecords(nil); err != nil {
+		return err
+	}
+	if err := t.SaveTableInfo("info"); err != nil {
+		return err
+	}
 	sybil.FLAGS.WRITE_BLOCK_INFO = true
 
 	loadSpec := t.NewLoadSpec()
@@ -41,7 +45,8 @@ func runIndexCmdLine(flags *sybil.FlagDefs, ints []string) error {
 			return err
 		}
 	}
-	t.LoadRecords(&loadSpec)
-	t.SaveTableInfo("info")
-	return nil
+	if _, err := t.LoadRecords(&loadSpec); err != nil {
+		return err
+	}
+	return t.SaveTableInfo("info")
 }

--- a/src/cmd/cmd_ingest.go
+++ b/src/cmd/cmd_ingest.go
@@ -118,7 +118,9 @@ func importCsvRecords() error {
 
 		}
 
-		t.ChunkAndSave()
+		if err := t.ChunkAndSave(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -197,7 +199,9 @@ func importJSONRecords(jsonPath string) error {
 				ingestDictionary(r, &dict, "")
 
 			}
-			t.ChunkAndSave()
+			if err := t.ChunkAndSave(); err != nil {
+				return err
+			}
 		}
 
 	}

--- a/src/cmd/cmd_ingest.go
+++ b/src/cmd/cmd_ingest.go
@@ -261,8 +261,8 @@ func RunIngestCmdLine() {
 	// someone else
 	var loadedTable = false
 	for i := 0; i < TABLE_INFO_GRABS; i++ {
-		loaded := t.LoadTableInfo()
-		if loaded || !t.HasFlagFile() {
+		loadErr := t.LoadTableInfo()
+		if loadErr == nil || !t.HasFlagFile() {
 			loadedTable = true
 			break
 		}

--- a/src/cmd/cmd_ingest.go
+++ b/src/cmd/cmd_ingest.go
@@ -70,8 +70,8 @@ func ingestDictionary(r *sybil.Record, recordmap *Dictionary, prefix string) err
 			sybil.Debug(fmt.Sprintf("TYPE %T IS UNKNOWN FOR FIELD", iv), keyName)
 		}
 		if err != nil {
-			// TODO: consider if there should be a relaxed mode
-			return errors.Wrap(err, fmt.Sprintf("issue loading %v", keyName))
+			// TODO: collect error counters?
+			sybil.Debug("INGEST RECORD ISSUE:", errors.Wrap(err, fmt.Sprintf("issue with field %v", keyName)))
 		}
 	}
 	return nil
@@ -123,12 +123,13 @@ func importCsvRecords() error {
 				err = r.AddStrField(fieldName, v)
 			}
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("issue loading %v", fieldName))
+				sybil.Debug("INGEST RECORD ISSUE:", errors.Wrap(err, fmt.Sprintf("issue loading %v", fieldName)))
 			}
 		}
 
 		if err := t.ChunkAndSave(); err != nil {
-			return err
+			// TODO: collect error counters?
+			sybil.Debug("INGEST RECORD ISSUE:", err)
 		}
 	}
 	return nil
@@ -209,10 +210,12 @@ func importJSONRecords(jsonPath string) error {
 				err = ingestDictionary(r, &dict, "")
 			}
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("issue with record %v", i))
+				// TODO: collect error counters?
+				sybil.Debug("INGEST RECORD ISSUE:", errors.Wrap(err, fmt.Sprintf("issue with record %v", i)))
 			}
 			if err := t.ChunkAndSave(); err != nil {
-				return err
+				// TODO: collect error counters?
+				sybil.Debug("INGEST RECORD ISSUE:", err)
 			}
 		}
 

--- a/src/cmd/cmd_ingest.go
+++ b/src/cmd/cmd_ingest.go
@@ -13,11 +13,10 @@ import (
 	"time"
 
 	"github.com/logv/sybil/src/sybil"
+	"github.com/pkg/errors"
 )
 
 type Dictionary map[string]interface{}
-
-var JSON_PATH string
 
 // how many times we try to grab table info when ingesting
 var TABLE_INFO_GRABS = 10
@@ -74,7 +73,7 @@ func ingestDictionary(r *sybil.Record, recordmap *Dictionary, prefix string) {
 
 var IMPORTED_COUNT = 0
 
-func importCsvRecords() {
+func importCsvRecords() error {
 	// For importing CSV records, we need to validate the headers, then we just
 	// read in and fill out record fields!
 	scanner := csv.NewReader(os.Stdin)
@@ -82,7 +81,7 @@ func importCsvRecords() {
 	if err == nil {
 		sybil.Debug("HEADER FIELDS FOR CSV ARE", headerFields)
 	} else {
-		sybil.Error("ERROR READING CSV HEADER", err)
+		return errors.Wrap(err, "error reading csv header")
 	}
 
 	t := sybil.GetTable(sybil.FLAGS.TABLE)
@@ -121,7 +120,7 @@ func importCsvRecords() {
 
 		t.ChunkAndSave()
 	}
-
+	return nil
 }
 
 func jsonQuery(obj *interface{}, path []string) []interface{} {
@@ -165,10 +164,10 @@ func jsonQuery(obj *interface{}, path []string) []interface{} {
 	return nil
 }
 
-func importJSONRecords() {
+func importJSONRecords(jsonPath string) error {
 	t := sybil.GetTable(sybil.FLAGS.TABLE)
 
-	path := strings.Split(JSON_PATH, ".")
+	path := strings.Split(jsonPath, ".")
 	sybil.Debug("PATH IS", path)
 
 	dec := json.NewDecoder(os.Stdin)
@@ -203,6 +202,7 @@ func importJSONRecords() {
 
 	}
 
+	return nil
 }
 
 var INT_CAST = make(map[string]bool)
@@ -218,36 +218,39 @@ func RunIngestCmdLine() {
 	flag.BoolVar(&sybil.FLAGS.SKIP_COMPACT, "skip-compact", false, "skip auto compaction during ingest")
 
 	flag.Parse()
+	if err := runIngestCmdLine(&sybil.FLAGS, *ingestfile, *fInts, *fCsv, *fExcludes, *fJSONPath, *fReopen); err != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrap(err, "ingest"))
+		os.Exit(1)
+	}
+}
 
-	digestfile := *ingestfile
+func runIngestCmdLine(flags *sybil.FlagDefs, digestFile string, ints string, csv bool, excludes string, jsonPath string, filePath string) error {
 
-	if sybil.FLAGS.TABLE == "" {
+	if flags.TABLE == "" {
 		flag.PrintDefaults()
-		return
+		return sybil.ErrMissingTable
 	}
 
-	JSON_PATH = *fJSONPath
+	if filePath != "" {
 
-	if *fReopen != "" {
-
-		infile, err := os.OpenFile(*fReopen, syscall.O_RDONLY|syscall.O_CREAT, 0666)
+		infile, err := os.OpenFile(filePath, syscall.O_RDONLY|syscall.O_CREAT, 0666)
 		if err != nil {
-			sybil.Error("ERROR OPENING INFILE", err)
+			return errors.Wrap(err, "error opening infile")
 		}
 
 		os.Stdin = infile
 
 	}
 
-	if sybil.FLAGS.PROFILE {
+	if flags.PROFILE {
 		profile := sybil.RUN_PROFILER()
 		defer profile.Start().Stop()
 	}
 
-	for _, v := range strings.Split(*fInts, ",") {
+	for _, v := range strings.Split(ints, ",") {
 		INT_CAST[v] = true
 	}
-	for _, v := range strings.Split(*fExcludes, ",") {
+	for _, v := range strings.Split(excludes, ",") {
 		EXCLUDES[v] = true
 	}
 
@@ -255,13 +258,14 @@ func RunIngestCmdLine() {
 		sybil.Debug("EXCLUDING COLUMN", k)
 	}
 
-	t := sybil.GetTable(sybil.FLAGS.TABLE)
+	t := sybil.GetTable(flags.TABLE)
 
 	// We have 5 tries to load table info, just in case the lock is held by
 	// someone else
 	var loadedTable = false
+	var loadErr error
 	for i := 0; i < TABLE_INFO_GRABS; i++ {
-		loadErr := t.LoadTableInfo()
+		loadErr = t.LoadTableInfo()
 		if loadErr == nil || !t.HasFlagFile() {
 			loadedTable = true
 			break
@@ -272,15 +276,21 @@ func RunIngestCmdLine() {
 	if !loadedTable {
 		if t.HasFlagFile() {
 			sybil.Warn("INGESTOR COULDNT READ TABLE INFO, LOSING SAMPLES")
-			return
+			if loadErr == nil {
+				loadErr = fmt.Errorf("unknown (nil) error")
+			}
+			return errors.Wrap(loadErr, "issue loading existing table")
 		}
 	}
 
-	if !*fCsv {
-		importJSONRecords()
+	var err error
+	if !csv {
+		err = importJSONRecords(jsonPath)
 	} else {
-		importCsvRecords()
+		err = importCsvRecords()
 	}
-
-	t.IngestRecords(digestfile)
+	if err != nil {
+		return err
+	}
+	return t.IngestRecords(digestFile)
 }

--- a/src/cmd/cmd_inspect.go
+++ b/src/cmd/cmd_inspect.go
@@ -2,82 +2,86 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/logv/sybil/src/sybil"
+	"github.com/pkg/errors"
 )
 
-func decodeTableInfo(digestFile *string) bool {
-	dec := sybil.GetFileDecoder(*digestFile)
+func decodeTableInfo(digestFile *string) error {
+	dec, err := sybil.GetFileDecoder(*digestFile)
+	if err != nil {
+		return err
+	}
 
 	savedTable := sybil.Table{}
-	err := dec.Decode(&savedTable)
+	if err = dec.Decode(&savedTable); err != nil {
+		return err
+	}
 
-	if err != nil || len(savedTable.KeyTable) == 0 {
-		return false
+	if len(savedTable.KeyTable) == 0 {
+		return fmt.Errorf("empty keytable")
 	}
 
 	sybil.Print("TABLE INFO", savedTable)
 
-	return true
-
+	return nil
 }
 
-func decodeInfoCol(digestFile *string) bool {
-	dec := sybil.GetFileDecoder(*digestFile)
+func decodeInfoCol(digestFile *string) error {
+	dec, err := sybil.GetFileDecoder(*digestFile)
+	if err != nil {
+		return err
+	}
 
 	info := sybil.SavedColumnInfo{}
-	err := dec.Decode(&info)
-
-	if err != nil {
-		sybil.Print("ERROR", err)
-		return false
+	if err := dec.Decode(&info); err != nil {
+		return err
 	}
 
 	sybil.Print("INFO COL", info)
 
-	return true
-
+	return nil
 }
 
-func decodeIntCol(digestFile *string) bool {
-	dec := sybil.GetFileDecoder(*digestFile)
+func decodeIntCol(digestFile *string) error {
+	dec, err := sybil.GetFileDecoder(*digestFile)
+	if err != nil {
+		return err
+	}
 
 	info := sybil.SavedIntColumn{}
-	err := dec.Decode(&info)
-
-	if err != nil {
-		sybil.Print("ERROR", err)
-		return false
+	if err := dec.Decode(&info); err != nil {
+		return err
 	}
 
 	sybil.Print("INT COL", info)
 
-	return true
-
+	return nil
 }
 
-func decodeStrCol(digestFile *string) bool {
-	dec := sybil.GetFileDecoder(*digestFile)
+func decodeStrCol(digestFile *string) error {
+	dec, err := sybil.GetFileDecoder(*digestFile)
+	if err != nil {
+		return err
+	}
 
 	info := sybil.SavedStrColumn{}
-	err := dec.Decode(&info)
+	if err := dec.Decode(&info); err != nil {
+		return err
+	}
 
 	bins := make([]string, 0)
 	for _, bin := range info.Bins {
 		bins = append(bins, strconv.FormatInt(int64(len(bin.Records)), 10))
 	}
 
-	if err != nil {
-		sybil.Print("ERROR", err)
-		return false
-	}
-
 	sybil.Print("STR COL", info)
 	sybil.Print("BINS ARE", bins)
 
-	return true
-
+	return nil
 }
 
 // TODO: make a list of potential types that can be decoded into
@@ -85,23 +89,44 @@ func RunInspectCmdLine() {
 	digestFile := flag.String("file", "", "Name of file to inspect")
 	flag.Parse()
 
-	if *digestFile == "" || digestFile == nil {
+	if *digestFile == "" {
 		sybil.Print("Please specify a file to inspect with the -file flag")
 		return
 	}
+	if err := runInspectCmdLine(digestFile); err != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrap(err, "query"))
+		os.Exit(1)
+	}
+}
 
-	if decodeTableInfo(digestFile) {
-		return
+func runInspectCmdLine(digestFile *string) error {
+	err := decodeTableInfo(digestFile)
+	if err == nil {
+		return nil
+	} else {
+		sybil.Debug("inspect encountered:", err)
 	}
 
-	if decodeInfoCol(digestFile) {
-		return
-	}
-	if decodeStrCol(digestFile) {
-		return
-	}
-	if decodeIntCol(digestFile) {
-		return
+	err = decodeInfoCol(digestFile)
+	if err == nil {
+		return nil
+	} else {
+		sybil.Debug("inspect encountered:", err)
 	}
 
+	err = decodeStrCol(digestFile)
+	if err == nil {
+		return nil
+	} else {
+		sybil.Debug("inspect encountered:", err)
+	}
+
+	err = decodeIntCol(digestFile)
+	if err == nil {
+		return nil
+	} else {
+		sybil.Debug("inspect encountered:", err)
+	}
+
+	return fmt.Errorf("no decoding succeeded")
 }

--- a/src/cmd/cmd_query.go
+++ b/src/cmd/cmd_query.go
@@ -114,7 +114,7 @@ func runQueryCmdLine(flags *sybil.FlagDefs) error {
 
 	t := sybil.GetTable(table)
 	if t.IsNotExist() {
-		sybil.Error(t.Name, "table can not be loaded or does not exist in", flags.DIR)
+		return fmt.Errorf("table %v does not exist in %v", flags.TABLE, flags.DIR)
 	}
 
 	ints := make([]string, 0)
@@ -199,8 +199,7 @@ func runQueryCmdLine(flags *sybil.FlagDefs) error {
 	for _, v := range t.KeyTable {
 		used[v]++
 		if used[v] > 1 {
-			sybil.Error("THERE IS A SERIOUS KEY TABLE INCONSISTENCY")
-			return nil
+			return sybil.ErrKeyTableInconsistent
 		}
 	}
 

--- a/src/cmd/cmd_query.go
+++ b/src/cmd/cmd_query.go
@@ -148,8 +148,12 @@ func runQueryCmdLine(flags *sybil.FlagDefs) error {
 
 	// LOAD TABLE INFOS BEFORE WE CREATE OUR FILTERS, SO WE CAN CREATE FILTERS ON
 	// THE RIGHT COLUMN ID
-	t.LoadTableInfo()
-	t.LoadRecords(nil)
+	if err := t.LoadTableInfo(); err != nil {
+		return errors.Wrap(err, "load table info failed")
+	}
+	if _, err := t.LoadRecords(nil); err != nil {
+		return errors.Wrap(err, "loading records failed")
+	}
 
 	count := 0
 	for _, block := range t.BlockList {
@@ -306,7 +310,9 @@ func runQueryCmdLine(flags *sybil.FlagDefs) error {
 		loadSpec.SkipDeleteBlocksAfterQuery = true
 		querySpec.Samples = true
 
-		t.LoadAndQueryRecords(&loadSpec, &querySpec)
+		if _, err := t.LoadAndQueryRecords(&loadSpec, &querySpec); err != nil {
+			return err
+		}
 
 		t.PrintSamples(printSpec)
 
@@ -329,7 +335,9 @@ func runQueryCmdLine(flags *sybil.FlagDefs) error {
 		start := time.Now()
 
 		if flags.LOAD_AND_QUERY {
-			t.LoadAndQueryRecords(&loadSpec, &querySpec)
+			if _, err := t.LoadAndQueryRecords(&loadSpec, &querySpec); err != nil {
+				return err
+			}
 
 			end := time.Now()
 			sybil.Debug("LOAD AND QUERY RECORDS TOOK", end.Sub(start))
@@ -346,7 +354,9 @@ func runQueryCmdLine(flags *sybil.FlagDefs) error {
 		t := sybil.GetTable(table)
 		flags.LOAD_AND_QUERY = false
 
-		t.LoadRecords(nil)
+		if _, err := t.LoadRecords(nil); err != nil {
+			return err
+		}
 		t.PrintColInfo(printSpec)
 	}
 

--- a/src/cmd/cmd_rebuild.go
+++ b/src/cmd/cmd_rebuild.go
@@ -49,11 +49,12 @@ func runRebuildCmdLine(flags *sybil.FlagDefs, replaceInfo bool, forceUpdate bool
 	if replaceInfo {
 		sybil.Print("REPLACING info.db WITH DATA COMPUTED ABOVE")
 		lock := sybil.Lock{Table: t, Name: "info"}
-		lock.ForceDeleteFile()
+		if err := lock.ForceDeleteFile(); err != nil {
+			return err
+		}
 		return t.SaveTableInfo("info")
 	} else {
 		sybil.Print("SAVING TO temp_info.db")
 		return t.SaveTableInfo("temp_info")
 	}
-	return nil
 }

--- a/src/cmd/cmd_rebuild.go
+++ b/src/cmd/cmd_rebuild.go
@@ -2,44 +2,58 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
+	"os"
 
 	"github.com/logv/sybil/src/sybil"
+	"github.com/pkg/errors"
 )
 
 func RunRebuildCmdLine() {
 	REPLACE_INFO := flag.Bool("replace", false, "Replace broken info.db if it exists")
 	FORCE_UPDATE := flag.Bool("force", false, "Force re-calculation of info.db, even if it exists")
 	flag.Parse()
+	if err := runRebuildCmdLine(&sybil.FLAGS, *REPLACE_INFO, *FORCE_UPDATE); err != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrap(err, "digest"))
+		os.Exit(1)
+	}
+}
 
-	if sybil.FLAGS.TABLE == "" {
+func runRebuildCmdLine(flags *sybil.FlagDefs, replaceInfo bool, forceUpdate bool) error {
+	if flags.TABLE == "" {
 		flag.PrintDefaults()
-		return
+		return sybil.ErrMissingTable
 	}
 
-	if sybil.FLAGS.PROFILE {
+	if flags.PROFILE {
 		profile := sybil.RUN_PROFILER()
 		defer profile.Start().Stop()
 	}
 
-	t := sybil.GetTable(sybil.FLAGS.TABLE)
+	t := sybil.GetTable(flags.TABLE)
 
-	loaded := t.LoadTableInfo() && !*FORCE_UPDATE
+	loadErr := t.LoadTableInfo()
+	if loadErr != nil {
+		return loadErr
+	}
+	loaded := loadErr == nil && !forceUpdate
 	if loaded {
 		sybil.Print("TABLE INFO ALREADY EXISTS, NOTHING TO REBUILD!")
-		return
+		return nil
 	}
 
 	t.DeduceTableInfoFromBlocks()
 
 	// TODO: prompt to see if this table info looks good and then write it to
 	// original info.db
-	if *REPLACE_INFO {
+	if replaceInfo {
 		sybil.Print("REPLACING info.db WITH DATA COMPUTED ABOVE")
 		lock := sybil.Lock{Table: t, Name: "info"}
 		lock.ForceDeleteFile()
-		t.SaveTableInfo("info")
+		return t.SaveTableInfo("info")
 	} else {
 		sybil.Print("SAVING TO temp_info.db")
-		t.SaveTableInfo("temp_info")
+		return t.SaveTableInfo("temp_info")
 	}
+	return nil
 }

--- a/src/cmd/cmd_trim.go
+++ b/src/cmd/cmd_trim.go
@@ -57,7 +57,7 @@ func runTrimCmdLine(flags *sybil.FlagDefs, mbLimit int, deleteBefore int, skipPr
 	}
 
 	t := sybil.GetTable(flags.TABLE)
-	if !t.LoadTableInfo() {
+	if err := t.LoadTableInfo(); err != nil {
 		// TODO use LoadTableInfo
 		return errors.New("Couldn't read table info, exiting early")
 	}

--- a/src/cmd/cmd_trim.go
+++ b/src/cmd/cmd_trim.go
@@ -58,8 +58,7 @@ func runTrimCmdLine(flags *sybil.FlagDefs, mbLimit int, deleteBefore int, skipPr
 
 	t := sybil.GetTable(flags.TABLE)
 	if err := t.LoadTableInfo(); err != nil {
-		// TODO use LoadTableInfo
-		return errors.New("Couldn't read table info, exiting early")
+		return err
 	}
 
 	loadSpec := t.NewLoadSpec()
@@ -96,7 +95,9 @@ func runTrimCmdLine(flags *sybil.FlagDefs, mbLimit int, deleteBefore int, skipPr
 		for _, b := range toTrim {
 			sybil.Debug("DELETING", b.Name)
 			if len(b.Name) > 5 {
-				os.RemoveAll(b.Name)
+				if err := os.RemoveAll(b.Name); err != nil {
+					return errors.Wrap(err, fmt.Sprintf("removing '%v' failed", b.Name))
+				}
 			} else {
 				sybil.Debug("REFUSING TO DELETE", b.Name)
 			}

--- a/src/cmd/cmd_trim.go
+++ b/src/cmd/cmd_trim.go
@@ -71,7 +71,10 @@ func runTrimCmdLine(flags *sybil.FlagDefs, mbLimit int, deleteBefore int, skipPr
 	trimSpec.DeleteBefore = int64(deleteBefore)
 	trimSpec.MBLimit = int64(mbLimit)
 
-	toTrim := t.TrimTable(&trimSpec)
+	toTrim, err := t.TrimTable(&trimSpec)
+	if err != nil {
+		return err
+	}
 
 	sybil.Debug("FOUND", len(toTrim), "CANDIDATE BLOCKS FOR TRIMMING")
 	if len(toTrim) > 0 {

--- a/src/cmd/cmd_trim.go
+++ b/src/cmd/cmd_trim.go
@@ -9,20 +9,20 @@ import (
 	"github.com/pkg/errors"
 )
 
-func askConfirmation() bool {
+func askConfirmation() (bool, error) {
 
 	var response string
 	_, err := fmt.Scanln(&response)
 	if err != nil {
-		sybil.Error(err)
+		return false, err
 	}
 
 	if response == "Y" {
-		return true
+		return true, nil
 	}
 
 	if response == "N" {
-		return false
+		return false, nil
 	}
 
 	fmt.Println("Y or N only")
@@ -84,9 +84,9 @@ func runTrimCmdLine(flags *sybil.FlagDefs, mbLimit int, deleteBefore int, skipPr
 		if !skipPrompt {
 			// TODO: prompt for deletion
 			fmt.Println("DELETE THE ABOVE BLOCKS? (Y/N)")
-			if !askConfirmation() {
+			if ok, err := askConfirmation(); !ok {
 				sybil.Debug("ABORTING")
-				return nil
+				return err
 			}
 
 		}

--- a/src/cmd/tc
+++ b/src/cmd/tc
@@ -1,0 +1,1 @@
+../../workdir/query/corpus/flags-45f65bd773da10889558682dae055023.json

--- a/src/sybil/column_store_io.go
+++ b/src/sybil/column_store_io.go
@@ -628,14 +628,14 @@ func (tb *TableBlock) unpackStrCol(dec FileDecoder, info SavedColumnInfo, replac
 	return nil
 }
 
-func (tb *TableBlock) unpackSetCol(dec FileDecoder, info SavedColumnInfo) {
+func (tb *TableBlock) unpackSetCol(dec FileDecoder, info SavedColumnInfo) error {
 	records := tb.RecordList
 
 	savedCol := NewSavedSetColumn()
 	into := &savedCol
 	err := dec.Decode(into)
 	if err != nil {
-		Debug("DECODE COL ERR:", err)
+		return err
 	}
 
 	keyTableLen := len(tb.table.KeyTable)
@@ -644,7 +644,7 @@ func (tb *TableBlock) unpackSetCol(dec FileDecoder, info SavedColumnInfo) {
 
 	if int(colID) >= keyTableLen {
 		Debug("IGNORING SET COLUMN", into.Name, "SINCE ITS NOT IN KEY TABLE IN BLOCK", tb.Name)
-		return
+		return nil
 	}
 
 	col := tb.GetColumnInfo(colID)
@@ -689,6 +689,7 @@ func (tb *TableBlock) unpackSetCol(dec FileDecoder, info SavedColumnInfo) {
 			records[r].Populated[colID] = SET_VAL
 		}
 	}
+	return nil
 }
 
 func (tb *TableBlock) unpackIntCol(dec FileDecoder, info SavedColumnInfo) error {

--- a/src/sybil/column_store_io.go
+++ b/src/sybil/column_store_io.go
@@ -412,7 +412,7 @@ func (tb *TableBlock) SeparateRecordsIntoColumns() SeparatedColumns {
 
 }
 
-func (tb *TableBlock) SaveToColumns(filename string) bool {
+func (tb *TableBlock) SaveToColumns(filename string) error {
 	dirname := filename
 
 	// Important to set the BLOCK's dirName so we can keep track
@@ -420,9 +420,9 @@ func (tb *TableBlock) SaveToColumns(filename string) bool {
 	tb.Name = dirname
 
 	defer tb.table.ReleaseBlockLock(filename)
-	if !tb.table.GrabBlockLock(filename) {
+	if err := tb.table.GrabBlockLock(filename); err != nil {
 		Debug("Can't grab lock to save block", filename)
-		return false
+		return err
 	}
 
 	partialname := fmt.Sprintf("%s.partial", dirname)
@@ -482,7 +482,7 @@ func (tb *TableBlock) SaveToColumns(filename string) bool {
 	}
 
 	Debug("RELEASING BLOCK", tb.Name)
-	return true
+	return nil
 
 }
 

--- a/src/sybil/column_store_io.go
+++ b/src/sybil/column_store_io.go
@@ -362,10 +362,8 @@ func (tb *TableBlock) SaveInfoToColumns(dirname string) error {
 	}
 
 	w, _ := os.Create(colFname)
-	if _, err := network.WriteTo(w); err != nil {
-		return err
-	}
-	return nil
+	_, err = network.WriteTo(w)
+	return err
 }
 
 type SeparatedColumns struct {

--- a/src/sybil/column_store_io.go
+++ b/src/sybil/column_store_io.go
@@ -483,7 +483,6 @@ func (tb *TableBlock) SaveToColumns(filename string) error {
 
 	// TODO:
 	if nb == nil || nb.Info.NumRecords != int32(len(tb.RecordList)) {
-		// TODO//Error("COULDNT VALIDATE CONSISTENCY FOR RECENTLY SAVED BLOCK!", filename)
 		return fmt.Errorf("could not validate consistency for recently saved block %v", filename)
 	}
 
@@ -493,7 +492,6 @@ func (tb *TableBlock) SaveToColumns(filename string) error {
 			return err
 		}
 		if nb == nil || len(nb.RecordList) != len(tb.RecordList) {
-			// TODO//Error("DEEP VALIDATION OF BLOCK FAILED CONSISTENCY CHECK!", filename)
 			return fmt.Errorf("deep validation of block failed consistency check %v", filename)
 		}
 	}

--- a/src/sybil/column_store_io.go
+++ b/src/sybil/column_store_io.go
@@ -475,7 +475,10 @@ func (tb *TableBlock) SaveToColumns(filename string) error {
 	// For now, we load info.db and check NumRecords inside it to prevent
 	// catastrophics, but we could load everything potentially
 	start = time.Now()
-	nb := tb.table.LoadBlockFromDir(partialname, nil, false, nil)
+	nb, err := tb.table.LoadBlockFromDir(partialname, nil, false, nil)
+	if err != nil {
+		return err
+	}
 	end = time.Now()
 
 	// TODO:
@@ -485,7 +488,10 @@ func (tb *TableBlock) SaveToColumns(filename string) error {
 	}
 
 	if DEBUG_RECORD_CONSISTENCY {
-		nb = tb.table.LoadBlockFromDir(partialname, nil, true, nil)
+		nb, err = tb.table.LoadBlockFromDir(partialname, nil, true, nil)
+		if err != nil {
+			return err
+		}
 		if nb == nil || len(nb.RecordList) != len(tb.RecordList) {
 			// TODO//Error("DEEP VALIDATION OF BLOCK FAILED CONSISTENCY CHECK!", filename)
 			return fmt.Errorf("deep validation of block failed consistency check %v", filename)
@@ -497,7 +503,7 @@ func (tb *TableBlock) SaveToColumns(filename string) error {
 	if err := os.RemoveAll(oldblock); err != nil {
 		return err
 	}
-	err := RenameAndMod(dirname, oldblock)
+	err = RenameAndMod(dirname, oldblock)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("error renaming block %v to %v", dirname, oldblock))
 	}

--- a/src/sybil/column_store_test.go
+++ b/src/sybil/column_store_test.go
@@ -28,10 +28,15 @@ func TestTableDigestRowRecords(t *testing.T) {
 	FLAGS.TABLE = tableName // TODO: eliminate global use
 	FLAGS.READ_INGESTION_LOG = true
 
-	nt.LoadTableInfo()
-	nt.LoadRecords(&LoadSpec{
+	if err := nt.LoadTableInfo(); err != nil {
+		t.Error(err)
+	}
+	_, err := nt.LoadRecords(&LoadSpec{
 		SkipDeleteBlocksAfterQuery: true,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(nt.RowBlock.RecordList) != CHUNK_SIZE*blockCount {
 		t.Error("Row Store didn't read back right number of records", len(nt.RowBlock.RecordList))
@@ -41,12 +46,16 @@ func TestTableDigestRowRecords(t *testing.T) {
 		t.Error("Found other records than rowblock")
 	}
 
-	nt.DigestRecords()
+	if err := nt.DigestRecords(); err != nil {
+		t.Error(err)
+	}
 
 	unloadTestTable(tableName)
 
 	nt = GetTable(tableName)
-	nt.LoadRecords(nil)
+	if _, err := nt.LoadRecords(nil); err != nil {
+		t.Error(err)
+	}
 
 	count := int32(0)
 	for _, b := range nt.BlockList {
@@ -83,10 +92,15 @@ func TestColumnStoreFileNames(t *testing.T) {
 	FLAGS.TABLE = tableName // TODO: eliminate global use
 	FLAGS.READ_INGESTION_LOG = true
 
-	nt.LoadTableInfo()
-	nt.LoadRecords(&LoadSpec{
+	if err := nt.LoadTableInfo(); err != nil {
+		t.Error(err)
+	}
+	_, err := nt.LoadRecords(&LoadSpec{
 		SkipDeleteBlocksAfterQuery: true,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(nt.RowBlock.RecordList) != CHUNK_SIZE*blockCount {
 		t.Error("Row Store didn't read back right number of records", len(nt.RowBlock.RecordList))
@@ -96,12 +110,16 @@ func TestColumnStoreFileNames(t *testing.T) {
 		t.Error("Found other records than rowblock")
 	}
 
-	nt.DigestRecords()
+	if err := nt.DigestRecords(); err != nil {
+		t.Error(err)
+	}
 
 	unloadTestTable(tableName)
 
 	nt = GetTable(tableName)
-	nt.LoadRecords(nil)
+	if _, err := nt.LoadRecords(nil); err != nil {
+		t.Error(err)
+	}
 
 	count := int32(0)
 
@@ -161,10 +179,15 @@ func TestBigIntColumns(t *testing.T) {
 	FLAGS.TABLE = tableName // TODO: eliminate global use
 	FLAGS.READ_INGESTION_LOG = true
 
-	nt.LoadTableInfo()
-	nt.LoadRecords(&LoadSpec{
+	if err := nt.LoadTableInfo(); err != nil {
+		t.Error(err)
+	}
+	_, err := nt.LoadRecords(&LoadSpec{
 		SkipDeleteBlocksAfterQuery: true,
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(nt.RowBlock.RecordList) != CHUNK_SIZE*blockCount {
 		t.Error("Row Store didn't read back right number of records", len(nt.RowBlock.RecordList))
@@ -174,7 +197,9 @@ func TestBigIntColumns(t *testing.T) {
 		t.Error("Found other records than rowblock")
 	}
 
-	nt.DigestRecords()
+	if err := nt.DigestRecords(); err != nil {
+		t.Error(err)
+	}
 
 	unloadTestTable(tableName)
 
@@ -185,7 +210,9 @@ func TestBigIntColumns(t *testing.T) {
 	querySpec := newQuerySpec()
 	querySpec.Samples = true
 	querySpec.Limit = 1000
-	nt.LoadAndQueryRecords(&loadSpec, querySpec)
+	if _, err := nt.LoadAndQueryRecords(&loadSpec, querySpec); err != nil {
+		t.Error(err)
+	}
 
 	count := int32(0)
 	Debug("MIN VALUE BEING CHECKED FOR IS", minVal, "2^32 is", 1<<32)

--- a/src/sybil/config.go
+++ b/src/sybil/config.go
@@ -115,11 +115,8 @@ func EncodeFlags() {
 	FLAGS.ENCODE_FLAGS = oldEncode
 }
 
-func DecodeFlags() {
+func DecodeFlags() error {
 	Debug("READING ENCODED FLAGS FROM STDIN")
 	dec := gob.NewDecoder(os.Stdin)
-	err := dec.Decode(&FLAGS)
-	if err != nil {
-		Error("ERROR DECODING FLAGS", err)
-	}
+	return dec.Decode(&FLAGS)
 }

--- a/src/sybil/debug.go
+++ b/src/sybil/debug.go
@@ -22,7 +22,3 @@ func Debug(args ...interface{}) {
 		log.Println(args...)
 	}
 }
-
-func Error(args ...interface{}) {
-	log.Fatalln(append([]interface{}{"ERROR"}, args...)...)
-}

--- a/src/sybil/errors.go
+++ b/src/sybil/errors.go
@@ -6,9 +6,10 @@ import (
 )
 
 var (
-	ErrMissingTable = errors.New("missing table")
-	ErrLockTimeout  = errors.New("lock timeout")
-	ErrLockBroken   = errors.New("lock broken")
+	ErrMissingTable         = errors.New("missing table")
+	ErrLockTimeout          = errors.New("lock timeout")
+	ErrLockBroken           = errors.New("lock broken")
+	ErrKeyTableInconsistent = errors.New("key table is inconsistent")
 )
 
 type ErrMissingColumn struct {

--- a/src/sybil/errors.go
+++ b/src/sybil/errors.go
@@ -7,6 +7,8 @@ import (
 
 var (
 	ErrMissingTable = errors.New("missing table")
+	ErrLockTimeout  = errors.New("lock timeout")
+	ErrLockBroken   = errors.New("lock broken")
 )
 
 type ErrMissingColumn struct {
@@ -24,4 +26,12 @@ type ErrColumnTypeMismatch struct {
 
 func (e ErrColumnTypeMismatch) Error() string {
 	return fmt.Sprintf("column '%s' is not of type %s", e.column, e.expected)
+}
+
+type ErrUnrecoverableLock struct {
+	lockfile string
+}
+
+func (e ErrUnrecoverableLock) Error() string {
+	return fmt.Sprintf("recovery failed for broken lock file: '%s'", e.lockfile)
 }

--- a/src/sybil/errors.go
+++ b/src/sybil/errors.go
@@ -1,0 +1,27 @@
+package sybil
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrMissingTable = errors.New("missing table")
+)
+
+type ErrMissingColumn struct {
+	column string
+}
+
+func (e ErrMissingColumn) Error() string {
+	return fmt.Sprintf("column '%s' is missing", e.column)
+}
+
+type ErrColumnTypeMismatch struct {
+	column   string
+	expected string
+}
+
+func (e ErrColumnTypeMismatch) Error() string {
+	return fmt.Sprintf("column '%s' is not of type %s", e.column, e.expected)
+}

--- a/src/sybil/file_decoder.go
+++ b/src/sybil/file_decoder.go
@@ -1,11 +1,12 @@
 package sybil
 
-import "fmt"
-
-import "os"
-import "strings"
-import "encoding/gob"
-import "compress/gzip"
+import (
+	"compress/gzip"
+	"encoding/gob"
+	"fmt"
+	"os"
+	"strings"
+)
 
 var GOB_GZIP_EXT = ".db.gz"
 
@@ -24,7 +25,10 @@ func (gfd GobFileDecoder) CloseFile() error {
 }
 
 func decodeInto(filename string, obj interface{}) error {
-	dec := GetFileDecoder(filename)
+	dec, err := GetFileDecoder(filename)
+	if err != nil {
+		return err
+	}
 
 	if err := dec.Decode(obj); err != nil {
 		return err
@@ -32,50 +36,50 @@ func decodeInto(filename string, obj interface{}) error {
 	return dec.CloseFile()
 }
 
-func getGobGzipDecoder(filename string) FileDecoder {
+func getGobGzipDecoder(filename string) (FileDecoder, error) {
 
 	var dec *gob.Decoder
 
 	file, err := os.Open(filename)
 	if err != nil {
 		Debug("COULDNT OPEN GZ", filename)
-		return GobFileDecoder{gob.NewDecoder(file), file}
+		return nil, err
 	}
 
 	reader, err := gzip.NewReader(file)
 	if err != nil {
 		Debug("COULDNT DECOMPRESS GZ", filename)
-		return GobFileDecoder{gob.NewDecoder(reader), file}
+		return nil, err
 	}
 
 	dec = gob.NewDecoder(reader)
-	return GobFileDecoder{dec, file}
+	return GobFileDecoder{dec, file}, nil
 }
 
-func GetFileDecoder(filename string) FileDecoder {
+func GetFileDecoder(filename string) (FileDecoder, error) {
 	// if the file ends with GZ ext, we use compressed decoder
 	if strings.HasSuffix(filename, GOB_GZIP_EXT) {
-		dec := getGobGzipDecoder(filename)
-		return dec
+		return getGobGzipDecoder(filename)
 	}
 
 	file, err := os.Open(filename)
 	// if we try to open the file and its missing, maybe there is a .gz version of it
 	if err != nil {
 		zfilename := fmt.Sprintf("%s%s", filename, GZIP_EXT)
-		_, err = os.Open(zfilename)
+		_, err := os.Open(zfilename)
 
 		// if we can open this file, we return compressed file decoder
 		if err == nil {
 			if strings.HasSuffix(zfilename, GOB_GZIP_EXT) {
-				dec := getGobGzipDecoder(zfilename)
-				return dec
+				return getGobGzipDecoder(zfilename)
 			}
 		}
 	}
-
+	if err != nil {
+		return nil, err
+	}
 	// otherwise, we just return vanilla decoder for this file
 	dec := GobFileDecoder{gob.NewDecoder(file), file}
-	return dec
+	return dec, nil
 
 }

--- a/src/sybil/file_decoder.go
+++ b/src/sybil/file_decoder.go
@@ -16,20 +16,20 @@ type GobFileDecoder struct {
 
 type FileDecoder interface {
 	Decode(interface{}) error
-	CloseFile() bool
+	CloseFile() error
 }
 
-func (gfd GobFileDecoder) CloseFile() bool {
-	gfd.File.Close()
-	return true
+func (gfd GobFileDecoder) CloseFile() error {
+	return gfd.File.Close()
 }
 
 func decodeInto(filename string, obj interface{}) error {
 	dec := GetFileDecoder(filename)
-	defer dec.CloseFile()
 
-	err := dec.Decode(obj)
-	return err
+	if err := dec.Decode(obj); err != nil {
+		return err
+	}
+	return dec.CloseFile()
 }
 
 func getGobGzipDecoder(filename string) FileDecoder {

--- a/src/sybil/file_decoder_test.go
+++ b/src/sybil/file_decoder_test.go
@@ -49,10 +49,16 @@ func TestOpenCompressedInfoDB(t *testing.T) {
 
 	}
 	zinfo := gzip.NewWriter(file)
-	zinfo.Write(dat)
-	zinfo.Close()
+	if _, err := zinfo.Write(dat); err != nil {
+		t.Error(err)
+	}
+	if err := zinfo.Close(); err != nil {
+		t.Error(err)
+	}
 
-	os.RemoveAll(filename)
+	if err := os.RemoveAll(filename); err != nil {
+		t.Error(err)
+	}
 	// END ZIPPING INFO.DB.GZ
 
 	loadSpec := nt.NewLoadSpec()
@@ -62,7 +68,9 @@ func TestOpenCompressedInfoDB(t *testing.T) {
 		t.Error("COULDNT LOAD ZIPPED TABLE INFO!", err)
 	}
 
-	nt.LoadRecords(&loadSpec)
+	if _, err := nt.LoadRecords(&loadSpec); err != nil {
+		t.Error(err)
+	}
 
 	var records = make([]*Record, 0)
 	for _, b := range nt.BlockList {
@@ -91,8 +99,12 @@ func TestOpenCompressedColumn(t *testing.T) {
 	}, blockCount)
 
 	nt := saveAndReloadTable(t, tableName, blockCount)
-	nt.DigestRecords()
-	nt.LoadRecords(nil)
+	if err := nt.DigestRecords(); err != nil {
+		t.Error(err)
+	}
+	if _, err := nt.LoadRecords(nil); err != nil {
+		t.Error(err)
+	}
 
 	blocks := nt.BlockList
 
@@ -119,8 +131,12 @@ func TestOpenCompressedColumn(t *testing.T) {
 
 			}
 			zinfo := gzip.NewWriter(file)
-			zinfo.Write(dat)
-			zinfo.Close()
+			if _, err := zinfo.Write(dat); err != nil {
+				t.Error(err)
+			}
+			if err := zinfo.Close(); err != nil {
+				t.Error(err)
+			}
 			Debug("CREATED GZIP FILE", zfilename)
 
 			err = os.RemoveAll(filename)
@@ -140,7 +156,9 @@ func TestOpenCompressedColumn(t *testing.T) {
 		t.Error("COULDNT LOAD ZIPPED TABLE INFO!", err)
 	}
 
-	bt.LoadRecords(&loadSpec)
+	if _, err := bt.LoadRecords(&loadSpec); err != nil {
+		t.Error(err)
+	}
 
 	var records = make([]*Record, 0)
 	for _, b := range bt.BlockList {

--- a/src/sybil/file_decoder_test.go
+++ b/src/sybil/file_decoder_test.go
@@ -58,9 +58,8 @@ func TestOpenCompressedInfoDB(t *testing.T) {
 	loadSpec := nt.NewLoadSpec()
 	loadSpec.LoadAllColumns = true
 
-	loaded := nt.LoadTableInfo()
-	if !loaded {
-		t.Error("COULDNT LOAD ZIPPED TABLE INFO!")
+	if err := nt.LoadTableInfo(); err != nil {
+		t.Error("COULDNT LOAD ZIPPED TABLE INFO!", err)
 	}
 
 	nt.LoadRecords(&loadSpec)
@@ -137,9 +136,8 @@ func TestOpenCompressedColumn(t *testing.T) {
 	loadSpec := bt.NewLoadSpec()
 	loadSpec.LoadAllColumns = true
 
-	loaded := bt.LoadTableInfo()
-	if !loaded {
-		t.Error("COULDNT LOAD ZIPPED TABLE INFO!")
+	if err := bt.LoadTableInfo(); err != nil {
+		t.Error("COULDNT LOAD ZIPPED TABLE INFO!", err)
 	}
 
 	bt.LoadRecords(&loadSpec)

--- a/src/sybil/filter_test.go
+++ b/src/sybil/filter_test.go
@@ -1,10 +1,12 @@
 package sybil
 
-import "testing"
-import "math/rand"
-import "strconv"
-import "math"
-import "strings"
+import (
+	"math"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+)
 
 func TestFilters(t *testing.T) {
 	tableName := getTestTableName(t)
@@ -39,8 +41,11 @@ func TestFilters(t *testing.T) {
 
 func testIntLt(t *testing.T, tableName string) {
 	nt := GetTable(tableName)
-	filters := []Filter{}
-	filters = append(filters, nt.IntFilter("age", "lt", 20))
+	loadSpec := nt.NewLoadSpec()
+	filters, err := BuildFilters(nt, &loadSpec, FilterSpec{Int: "age:lt:20"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	aggs := []Aggregation{}
 	aggs = append(aggs, nt.Aggregation("age", "avg"))
@@ -65,8 +70,11 @@ func testIntLt(t *testing.T, tableName string) {
 
 func testIntGt(t *testing.T, tableName string) {
 	nt := GetTable(tableName)
-	filters := []Filter{}
-	filters = append(filters, nt.IntFilter("age", "gt", 20))
+	loadSpec := nt.NewLoadSpec()
+	filters, err := BuildFilters(nt, &loadSpec, FilterSpec{Int: "age:gt:20"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	aggs := []Aggregation{}
 	aggs = append(aggs, nt.Aggregation("age", "avg"))
@@ -92,8 +100,11 @@ func testIntGt(t *testing.T, tableName string) {
 
 func testIntNeq(t *testing.T, tableName string) {
 	nt := GetTable(tableName)
-	filters := []Filter{}
-	filters = append(filters, nt.IntFilter("age", "neq", 20))
+	loadSpec := nt.NewLoadSpec()
+	filters, err := BuildFilters(nt, &loadSpec, FilterSpec{Int: "age:neq:20"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	aggs := []Aggregation{}
 	aggs = append(aggs, nt.Aggregation("age", "avg"))
@@ -126,8 +137,11 @@ func testIntNeq(t *testing.T, tableName string) {
 
 func testIntEq(t *testing.T, tableName string) {
 	nt := GetTable(tableName)
-	filters := []Filter{}
-	filters = append(filters, nt.IntFilter("age", "eq", 20))
+	loadSpec := nt.NewLoadSpec()
+	filters, err := BuildFilters(nt, &loadSpec, FilterSpec{Int: "age:eq:20"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	aggs := []Aggregation{}
 	aggs = append(aggs, nt.Aggregation("age", "avg"))
@@ -153,8 +167,11 @@ func testIntEq(t *testing.T, tableName string) {
 
 func testStrEq(t *testing.T, tableName string) {
 	nt := GetTable(tableName)
-	filters := []Filter{}
-	filters = append(filters, nt.StrFilter("age_str", "re", "20"))
+	loadSpec := nt.NewLoadSpec()
+	filters, err := BuildFilters(nt, &loadSpec, FilterSpec{Str: "age_str:re:20"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	aggs := []Aggregation{}
 	aggs = append(aggs, nt.Aggregation("age", "avg"))
@@ -184,8 +201,11 @@ func testStrEq(t *testing.T, tableName string) {
 
 func testStrNeq(t *testing.T, tableName string) {
 	nt := GetTable(tableName)
-	filters := []Filter{}
-	filters = append(filters, nt.StrFilter("age_str", "nre", "20"))
+	loadSpec := nt.NewLoadSpec()
+	filters, err := BuildFilters(nt, &loadSpec, FilterSpec{Str: "age_str:nre:20"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	aggs := []Aggregation{}
 	aggs = append(aggs, nt.Aggregation("age", "avg"))
@@ -210,8 +230,11 @@ func testStrNeq(t *testing.T, tableName string) {
 
 func testStrRe(t *testing.T, tableName string) {
 	nt := GetTable(tableName)
-	filters := []Filter{}
-	filters = append(filters, nt.StrFilter("age_str", "re", "^2"))
+	loadSpec := nt.NewLoadSpec()
+	filters, err := BuildFilters(nt, &loadSpec, FilterSpec{Str: "age_str:re:^2"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	aggs := []Aggregation{}
 	aggs = append(aggs, nt.Aggregation("age", "avg"))
@@ -241,8 +264,11 @@ func testStrRe(t *testing.T, tableName string) {
 
 func testSetIn(t *testing.T, tableName string) {
 	nt := GetTable(tableName)
-	filters := []Filter{}
-	filters = append(filters, nt.SetFilter("age_set", "in", "20"))
+	loadSpec := nt.NewLoadSpec()
+	filters, err := BuildFilters(nt, &loadSpec, FilterSpec{Set: "age_set:in:20"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	aggs := []Aggregation{}
 	aggs = append(aggs, nt.Aggregation("age", "avg"))
@@ -283,8 +309,11 @@ func testSetIn(t *testing.T, tableName string) {
 
 func testSetNin(t *testing.T, tableName string) {
 	nt := GetTable(tableName)
-	filters := []Filter{}
-	filters = append(filters, nt.SetFilter("age_set", "nin", "20"))
+	loadSpec := nt.NewLoadSpec()
+	filters, err := BuildFilters(nt, &loadSpec, FilterSpec{Set: "age_set:nin:20"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	aggs := []Aggregation{}
 	aggs = append(aggs, nt.Aggregation("age", "avg"))

--- a/src/sybil/helpers_test.go
+++ b/src/sybil/helpers_test.go
@@ -65,7 +65,9 @@ func saveAndReloadTable(t *testing.T, tableName string, expectedBlocks int) *Tab
 	unloadTestTable(tableName)
 
 	nt := GetTable(tableName)
-	nt.LoadTableInfo()
+	if err := nt.LoadTableInfo(); err != nil {
+		t.Error(err)
+	}
 
 	loadSpec := NewLoadSpec()
 	loadSpec.LoadAllColumns = true

--- a/src/sybil/helpers_test.go
+++ b/src/sybil/helpers_test.go
@@ -69,7 +69,10 @@ func saveAndReloadTable(t *testing.T, tableName string, expectedBlocks int) *Tab
 
 	loadSpec := NewLoadSpec()
 	loadSpec.LoadAllColumns = true
-	count := nt.LoadRecords(&loadSpec)
+	count, err := nt.LoadRecords(&loadSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if count != expectedCount {
 		t.Error("Wrote", expectedCount, "records, but read back", count)

--- a/src/sybil/ingest_test.go
+++ b/src/sybil/ingest_test.go
@@ -1,0 +1,10 @@
+package sybil
+
+import "testing"
+
+func TestIngestion(t *testing.T) {
+	tableName := getTestTableName(t)
+	deleteTestDb(tableName)
+	defer deleteTestDb(tableName)
+
+}

--- a/src/sybil/node_aggregator.go
+++ b/src/sybil/node_aggregator.go
@@ -56,7 +56,7 @@ func (vt *VTable) findResultsInDirs(dirs []string) map[string]*NodeResults {
 
 }
 
-func (vt *VTable) AggregateSamples(printSpec *PrintSpec, dirs []string) {
+func (vt *VTable) AggregateSamples(printSpec *PrintSpec, dirs []string) error {
 	Debug("AGGREGATING TABLE LIST")
 	allResults := vt.findResultsInDirs(dirs)
 
@@ -72,11 +72,10 @@ func (vt *VTable) AggregateSamples(printSpec *PrintSpec, dirs []string) {
 
 	// TODO: call into vt.PrintSamples later after adjusting how we store the samples
 	// on a per table basis
-	printJSON(samples)
-
+	return printJSON(samples)
 }
 
-func (vt *VTable) AggregateTables(printSpec *PrintSpec, dirs []string) {
+func (vt *VTable) AggregateTables(printSpec *PrintSpec, dirs []string) error {
 	Debug("AGGREGATING TABLE LIST")
 	allResults := vt.findResultsInDirs(dirs)
 	Debug("FOUND", len(allResults), "SPECS TO AGG")
@@ -98,7 +97,7 @@ func (vt *VTable) AggregateTables(printSpec *PrintSpec, dirs []string) {
 		tableArr = append(tableArr, table)
 	}
 
-	printTablesToOutput(printSpec, tableArr)
+	return printTablesToOutput(printSpec, tableArr)
 }
 
 func (vt *VTable) AggregateInfo(printSpec *PrintSpec, dirs []string) {

--- a/src/sybil/printer.go
+++ b/src/sybil/printer.go
@@ -12,16 +12,17 @@ import "io/ioutil"
 import "text/tabwriter"
 import "time"
 
-func printJSON(data interface{}) {
+func printJSON(data interface{}) error {
 	b, err := json.Marshal(data)
 	if err == nil {
 		os.Stdout.Write(b)
 	} else {
-		Error("JSON encoding error", err)
+		return err
 	}
+	return nil
 }
 
-func printTimeResults(printSpec *PrintSpec, querySpec *QuerySpec) {
+func printTimeResults(printSpec *PrintSpec, querySpec *QuerySpec) error {
 	Debug("PRINTING TIME RESULTS")
 	Debug("CHECKING SORT ORDER", len(querySpec.Sorted))
 
@@ -59,8 +60,7 @@ func printTimeResults(printSpec *PrintSpec, querySpec *QuerySpec) {
 			}
 		}
 
-		printJSON(marshalledResults)
-		return
+		return printJSON(marshalledResults)
 	}
 
 	w := new(tabwriter.Writer)
@@ -86,7 +86,7 @@ func printTimeResults(printSpec *PrintSpec, querySpec *QuerySpec) {
 		}
 	}
 
-	w.Flush()
+	return w.Flush()
 }
 
 func getSparseBuckets(buckets map[string]int64) map[string]int64 {
@@ -261,16 +261,16 @@ func printResults(printSpec *PrintSpec, querySpec *QuerySpec) {
 	}
 }
 
-func PrintBytes(obj interface{}) {
+func PrintBytes(obj interface{}) error {
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)
 	err := enc.Encode(obj)
 	if err != nil {
-		Warn("COULDNT ENCODE BYTES", err)
+		return err
 	}
 
 	Print(buf.String())
-
+	return nil
 }
 
 func encodeResults(qs *QuerySpec) {
@@ -431,7 +431,6 @@ func (t *Table) PrintSamples(printSpec *PrintSpec) {
 func ListTables() []string {
 	files, err := ioutil.ReadDir(FLAGS.DIR)
 	if err != nil {
-		Error("No tables found!")
 		return []string{}
 	}
 
@@ -452,10 +451,9 @@ func PrintTables(printSpec *PrintSpec) {
 
 }
 
-func printTablesToOutput(printSpec *PrintSpec, tables []string) {
+func printTablesToOutput(printSpec *PrintSpec, tables []string) error {
 	if printSpec.EncodeResults {
-		PrintBytes(NodeResults{Tables: tables})
-		return
+		return PrintBytes(NodeResults{Tables: tables})
 	}
 
 	if printSpec.JSON {
@@ -463,10 +461,10 @@ func printTablesToOutput(printSpec *PrintSpec, tables []string) {
 		if err == nil {
 			os.Stdout.Write(b)
 		} else {
-			Error("JSON encoding error", err)
+			return err
 		}
 
-		return
+		return nil
 	}
 
 	for _, name := range tables {
@@ -474,6 +472,7 @@ func printTablesToOutput(printSpec *PrintSpec, tables []string) {
 	}
 
 	fmt.Println("")
+	return nil
 }
 
 func (t *Table) getColsOfType(wantedType int8) []string {

--- a/src/sybil/printer.go
+++ b/src/sybil/printer.go
@@ -87,7 +87,6 @@ func printTimeResults(printSpec *PrintSpec, querySpec *QuerySpec) {
 	}
 
 	w.Flush()
-
 }
 
 func getSparseBuckets(buckets map[string]int64) map[string]int64 {

--- a/src/sybil/record.go
+++ b/src/sybil/record.go
@@ -1,5 +1,11 @@
 package sybil
 
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
 type Record struct {
 	Strs      []StrField
 	Ints      []IntField
@@ -85,7 +91,7 @@ func (r *Record) ResizeFields(length int16) {
 
 }
 
-func (r *Record) AddStrField(name string, val string) {
+func (r *Record) AddStrField(name string, val string) error {
 	nameID := r.block.getKeyID(name)
 
 	col := r.block.GetColumnInfo(nameID)
@@ -96,11 +102,12 @@ func (r *Record) AddStrField(name string, val string) {
 	r.Populated[nameID] = STR_VAL
 
 	if !r.block.table.setKeyType(nameID, STR_VAL) {
-		Error("COULDNT SET STR VAL", name, val, nameID)
+		return errors.New(fmt.Sprint("couldnt set str val", name, val, nameID))
 	}
+	return nil
 }
 
-func (r *Record) AddIntField(name string, val int64) {
+func (r *Record) AddIntField(name string, val int64) error {
 	nameID := r.block.getKeyID(name)
 	r.block.table.updateIntInfo(nameID, val)
 
@@ -108,11 +115,12 @@ func (r *Record) AddIntField(name string, val int64) {
 	r.Ints[nameID] = IntField(val)
 	r.Populated[nameID] = INT_VAL
 	if !r.block.table.setKeyType(nameID, INT_VAL) {
-		Error("COULDNT SET INT VAL", name, val, nameID)
+		return errors.New(fmt.Sprint("couldnt set int val", name, val, nameID))
 	}
+	return nil
 }
 
-func (r *Record) AddSetField(name string, val []string) {
+func (r *Record) AddSetField(name string, val []string) error {
 	nameID := r.block.getKeyID(name)
 	vals := make([]int32, len(val))
 	for i, v := range val {
@@ -128,8 +136,9 @@ func (r *Record) AddSetField(name string, val []string) {
 	r.SetMap[nameID] = SetField(vals)
 	r.Populated[nameID] = SET_VAL
 	if !r.block.table.setKeyType(nameID, SET_VAL) {
-		Error("COULDNT SET SET VAL", name, val, nameID)
+		return errors.New(fmt.Sprint("couldnt set set val", name, val, nameID))
 	}
+	return nil
 }
 
 var COPY_RECORD_INTERNS = false

--- a/src/sybil/row_store.go
+++ b/src/sybil/row_store.go
@@ -33,7 +33,7 @@ type SavedRecord struct {
 	Sets []RowSavedSet
 }
 
-func (s SavedRecord) toRecord(t *Table) *Record {
+func (s SavedRecord) toRecord(t *Table) (*Record, error) {
 	r := Record{}
 	r.Ints = IntArr{}
 	r.Strs = StrArr{}
@@ -61,15 +61,21 @@ func (s SavedRecord) toRecord(t *Table) *Record {
 	}
 
 	for _, v := range s.Strs {
-		r.AddStrField(t.getStringForKey(int(v.Name)), v.Value)
+		err := r.AddStrField(t.getStringForKey(int(v.Name)), v.Value)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	for _, v := range s.Sets {
-		r.AddSetField(t.getStringForKey(int(v.Name)), v.Value)
+		err := r.AddSetField(t.getStringForKey(int(v.Name)), v.Value)
+		if err != nil {
+			return nil, err
+		}
 		r.Populated[v.Name] = SET_VAL
 	}
 
-	return &r
+	return &r, nil
 }
 
 func (r Record) toSavedRecord() *SavedRecord {

--- a/src/sybil/row_store.go
+++ b/src/sybil/row_store.go
@@ -127,7 +127,7 @@ func (t *Table) LoadSavedRecordsFromLog(filename string) []*SavedRecord {
 	return marshalledRecords
 }
 
-func (t *Table) LoadRecordsFromLog(filename string) RecordList {
+func (t *Table) LoadRecordsFromLog(filename string) (RecordList, error) {
 	var marshalledRecords []*SavedRecord
 
 	// Create an encoder and send a value.
@@ -139,10 +139,12 @@ func (t *Table) LoadRecordsFromLog(filename string) RecordList {
 	ret := make(RecordList, len(marshalledRecords))
 
 	for i, r := range marshalledRecords {
-		ret[i] = r.toRecord(t)
+		ret[i], err = r.toRecord(t)
+		if err != nil {
+			return RecordList{}, err
+		}
 	}
-	return ret
-
+	return ret, nil
 }
 
 func (t *Table) AppendRecordsToLog(records RecordList, blockname string) error {

--- a/src/sybil/table_ingest.go
+++ b/src/sybil/table_ingest.go
@@ -2,6 +2,7 @@ package sybil
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
 	"strings"
@@ -41,7 +42,8 @@ func (t *Table) IngestRecords(blockname string) error {
 	}
 	t.newRecords = make(RecordList, 0)
 	if err := t.SaveTableInfo("info"); err != nil {
-		return err
+		//return errors.Wrap(err, "t.SaveTableInfo")
+		log.Println(err)
 	}
 	t.ReleaseRecords()
 

--- a/src/sybil/table_ingest.go
+++ b/src/sybil/table_ingest.go
@@ -2,7 +2,6 @@ package sybil
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -42,8 +41,7 @@ func (t *Table) IngestRecords(blockname string) error {
 	}
 	t.newRecords = make(RecordList, 0)
 	if err := t.SaveTableInfo("info"); err != nil {
-		//return errors.Wrap(err, "t.SaveTableInfo")
-		log.Println(err)
+		Warn(errors.Wrap(err, "t.SaveTableInfo"))
 	}
 	t.ReleaseRecords()
 

--- a/src/sybil/table_ingest.go
+++ b/src/sybil/table_ingest.go
@@ -32,16 +32,20 @@ func (t *Table) getNewCacheBlockFile() (*os.File, error) {
 }
 
 // Go through newRecords list and save all the new records out to a row store
-func (t *Table) IngestRecords(blockname string) {
+func (t *Table) IngestRecords(blockname string) error {
 	Debug("KEY TABLE", t.KeyTable)
 	Debug("KEY TYPES", t.KeyTypes)
 
-	t.AppendRecordsToLog(t.newRecords[:], blockname)
+	if err := t.AppendRecordsToLog(t.newRecords[:], blockname); err != nil {
+		return err}
 	t.newRecords = make(RecordList, 0)
-	t.SaveTableInfo("info")
+	if err := t.SaveTableInfo("info"); err != nil {
+		return err
+	}
 	t.ReleaseRecords()
 
 	t.MaybeCompactRecords()
+	return nil
 }
 
 // TODO: figure out how often we actually do a collation check by storing last

--- a/src/sybil/table_ingest.go
+++ b/src/sybil/table_ingest.go
@@ -37,7 +37,8 @@ func (t *Table) IngestRecords(blockname string) error {
 	Debug("KEY TYPES", t.KeyTypes)
 
 	if err := t.AppendRecordsToLog(t.newRecords[:], blockname); err != nil {
-		return err}
+		return err
+	}
 	t.newRecords = make(RecordList, 0)
 	if err := t.SaveTableInfo("info"); err != nil {
 		return err

--- a/src/sybil/table_io.go
+++ b/src/sybil/table_io.go
@@ -27,7 +27,7 @@ var BLOCKS_PER_CACHE_FILE = 64
 
 func (t *Table) saveTableInfo(fname string) error {
 	if err := t.GrabInfoLock(); err != nil {
-		return err
+		return errors.Wrap(err, "t.GrabInfoLock")
 	}
 
 	defer t.ReleaseInfoLock()

--- a/src/sybil/table_lock.go
+++ b/src/sybil/table_lock.go
@@ -62,8 +62,7 @@ func (l *InfoLock) Recover() error {
 	if err := t.LoadTableInfoFrom(infodb); err == nil {
 		Debug("LOADED REASONABLE TABLE INFO, DELETING LOCK")
 		l.ForceDeleteFile()
-	} else {
-		return errors.Wrap(err, "LoadTableInfoFrom")
+		return nil
 	}
 
 	err := t.LoadTableInfoFrom(backup)
@@ -102,7 +101,10 @@ func (l *DigestLock) Recover() error {
 func (l *BlockLock) Recover() error {
 	Debug("RECOVERING BLOCK LOCK", l.Name)
 	t := l.Table
-	tb := t.LoadBlockFromDir(l.Name, nil, true, nil)
+	tb, err := t.LoadBlockFromDir(l.Name, nil, true, nil)
+	if err != nil {
+		return err
+	}
 	if tb == nil || tb.Info == nil || tb.Info.NumRecords <= 0 {
 		Debug("BLOCK IS NO GOOD, TURNING IT INTO A BROKEN BLOCK")
 		// This block is not good! need to put it into remediation...

--- a/src/sybil/table_lock_test.go
+++ b/src/sybil/table_lock_test.go
@@ -13,9 +13,8 @@ func TestGrabInfoLock(t *testing.T) {
 
 	tbl.MakeDir()
 
-	grabbed := tbl.GrabInfoLock()
-	if !grabbed {
-		t.Errorf("COULD NOT GRAB INFO LOCK, tried %v", tableName)
+	if err := tbl.GrabInfoLock(); err != nil {
+		t.Errorf("COULD NOT GRAB INFO LOCK, tried %v - %v", tableName, err)
 	}
 }
 
@@ -32,7 +31,7 @@ func TestRecoverInfoLock(t *testing.T) {
 
 	tbl.MakeDir()
 
-	grabbed := tbl.GrabInfoLock()
+	grabbed := tbl.GrabInfoLock() == nil
 	if grabbed {
 		t.Error("GRABBED INFO LOCK WHEN IT ALREADY EXISTS AND BELONGS ELSEWHERE")
 	}
@@ -49,9 +48,8 @@ func TestGrabDigestLock(t *testing.T) {
 	tbl := GetTable(tableName)
 
 	tbl.MakeDir()
-	grabbed := tbl.GrabDigestLock()
-	if !grabbed {
-		t.Error("COULD NOT GRAB DIGEST LOCK")
+	if err := tbl.GrabDigestLock(); err != nil {
+		t.Error("COULD NOT GRAB DIGEST LOCK", err)
 	}
 }
 
@@ -64,15 +62,15 @@ func TestRecoverDigestLock(t *testing.T) {
 	tbl.MakeDir()
 
 	// first grab digest lock
-	if grabbed := tbl.GrabDigestLock(); !grabbed {
-		t.Error("COULD NOT GRAB DIGEST LOCK")
+	if err := tbl.GrabDigestLock(); err != nil {
+		t.Error("COULD NOT GRAB DIGEST LOCK", err)
 	}
 
 	lock := Lock{Table: tbl, Name: STOMACHE_DIR}
 	lock.ForceMakeFile(int64(0))
 
 	tbl.MakeDir()
-	grabbed := tbl.GrabDigestLock()
+	grabbed := tbl.GrabDigestLock() == nil
 	if grabbed {
 		t.Error("COULD GRAB DIGEST LOCK WHEN IT ARLEADY EXISTS")
 	}

--- a/src/sybil/table_query.go
+++ b/src/sybil/table_query.go
@@ -9,9 +9,11 @@ import (
 	"runtime/debug"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
-func (t *Table) LoadAndQueryRecords(loadSpec *LoadSpec, querySpec *QuerySpec) int {
+func (t *Table) LoadAndQueryRecords(loadSpec *LoadSpec, querySpec *QuerySpec) (int, error) {
 	waystart := time.Now()
 	Debug("LOADING", FLAGS.DIR, t.Name)
 
@@ -33,10 +35,9 @@ func (t *Table) LoadAndQueryRecords(loadSpec *LoadSpec, querySpec *QuerySpec) in
 	blockSpecs := make(map[string]*QuerySpec)
 	toCacheSpecs := make(map[string]*QuerySpec)
 
-	loadedInfo := t.LoadTableInfo()
-	if !loadedInfo {
+	if err := t.LoadTableInfo(); err != nil {
 		if t.HasFlagFile() {
-			return 0
+			return 0, errors.Wrap(err, "issue loading existing table")
 		}
 	}
 
@@ -352,6 +353,5 @@ func (t *Table) LoadAndQueryRecords(loadSpec *LoadSpec, querySpec *QuerySpec) in
 
 	t.WriteBlockCache()
 
-	return count
-
+	return count, nil
 }

--- a/src/sybil/table_trim.go
+++ b/src/sybil/table_trim.go
@@ -9,7 +9,7 @@ type TrimSpec struct {
 
 // List all the blocks that should be trimmed to keep the table within it's
 // memory limits
-func (t *Table) TrimTable(trimSpec *TrimSpec) []*TableBlock {
+func (t *Table) TrimTable(trimSpec *TrimSpec) ([]*TableBlock, error) {
 	t.LoadRecords(nil)
 	Debug("TRIMMING TABLE, MEMORY LIMIT", trimSpec.MBLimit, "TIME LIMIT", trimSpec.DeleteBefore)
 
@@ -21,7 +21,10 @@ func (t *Table) TrimTable(trimSpec *TrimSpec) []*TableBlock {
 			continue
 		}
 
-		block := t.LoadBlockFromDir(b.Name, nil, false, nil)
+		block, err := t.LoadBlockFromDir(b.Name, nil, false, nil)
+		if err != nil {
+			return nil, err
+		}
 		if block != nil {
 			if block.Info.IntInfoMap[FLAGS.TIME_COL] != nil {
 				block.table = t
@@ -54,5 +57,5 @@ func (t *Table) TrimTable(trimSpec *TrimSpec) []*TableBlock {
 		size += b.Size
 	}
 
-	return toTrim
+	return toTrim, nil
 }


### PR DESCRIPTION
This opts to return error values instead of allowing sybil.Error to shut the process down via log.Fatalln.

I think the most likely way this change will introduce a regression is that it will not allow any errors in a set of records to go ignored. I would say it carries moderate risk.

Fixes #74
