### PR TITLE
[fuzz] separate fuzzing functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cover.*
 *.pyc
 .starscope.db
 cscope.out
+workdir/

--- a/Makefile
+++ b/Makefile
@@ -78,17 +78,17 @@ default: all
 clean:
 	rm ./bin/*
 
-fuzz: bin/cmd-fuzz.zip
-	go-fuzz -bin=./bin/cmd-fuzz.zip -workdir=workdir
+fuzz: bin/cmd-fuzz-query.zip
+	go-fuzz -bin=./bin/cmd-fuzz-query.zip -workdir=workdir/query
 
-fuzzv: bin/cmd-fuzz.zip
-	FUZZDEBUG=1 go-fuzz -bin=./bin/cmd-fuzz.zip -workdir=workdir -testoutput -procs 1
+fuzzv: bin/cmd-fuzz-query.zip
+	FUZZDEBUG=1 go-fuzz -bin=./bin/cmd-fuzz-query.zip -workdir=workdir/query -testoutput -procs 1
 
 cleanfuzz:
-	rm ./bin/cmd-fuzz.zip
+	rm -f ./bin/cmd-fuzz*
 
-bin/cmd-fuzz.zip:
-	go-fuzz-build -o bin/cmd-fuzz.zip github.com/logv/sybil/src/cmd
+bin/cmd-fuzz-query.zip:
+	go-fuzz-build -func FuzzQuery -o bin/cmd-fuzz-query.zip github.com/logv/sybil/src/cmd
 
 .PHONY: tags
 .PHONY: query

--- a/src/cmd/fuzz.go
+++ b/src/cmd/fuzz.go
@@ -10,13 +10,7 @@ import (
 	"github.com/logv/sybil/src/sybil"
 )
 
-type F func(*sybil.FlagDefs) error
-
-var cmdFuncs = []F{
-	runQueryCmdLine,
-}
-
-func Fuzz(data []byte) int {
+func FuzzQuery(data []byte) int {
 	if len(data) < 1 {
 		return 0
 	}
@@ -34,12 +28,10 @@ func Fuzz(data []byte) int {
 		}
 		return 0
 	}
-	fn := cmdFuncs[int(data[0])%len(cmdFuncs)]
-
 	if print {
 		fmt.Println(&flags)
 	}
-	if err := fn(&flags); err != nil {
+	if err := runQueryCmdLine(&flags); err != nil {
 		if print {
 			fmt.Println("err:", err)
 		}


### PR DESCRIPTION
go-fuzz works better when a corpus is focused on one set of inputs

this separates existing fuzziing to only fuzz query